### PR TITLE
Fix a typo in get_instances that broke modifying fields

### DIFF
--- a/butterdb/butterdb.py
+++ b/butterdb/butterdb.py
@@ -143,7 +143,7 @@ class Model(object):
 
         for n, fields in enumerate([row for row in data if any(row)], start=1):
             instances.append(
-                cls._init_with_id(id, *fields[:len(cls.columns)]))
+                cls._init_with_id(n, *fields[:len(cls.columns)]))
 
         return instances
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -109,3 +109,19 @@ class TestModel(object):
         my_instance = FooModel.get_instances()[-1]
 
         assert_equal(my_instance.foo, test_dict)
+
+    def test_modify_existing(self):
+        # ensure there is something
+        foo, bar = 123, 456
+        instance = FooModel(foo, bar)
+        instance.commit()
+
+        assert_equal(instance.foo, foo)
+        assert_equal(instance.bar, bar)
+
+        # get a new instance to modify from there
+        new_instance = FooModel.get_instances()[-1]
+        new_instance.foo = bar
+        new_instance.commit()
+
+        assert_equal(new_instance.foo, bar)


### PR DESCRIPTION
Also added a test case to cover this behavior.

The error was:

```
TypeError: unsupported operand type(s) for +: 'builtin_function_or_method' and 'int'
```

And it's because model.id was being set to the builtin function "id" instead of the variable "n" from the enumerator.

---

Given the nature of this bug, I suspect I'm the only idiot using this for something nontrivial. 

Also, I liked the old name of the project better.
