### PR TITLE
Implement gspread OAuth2 connection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,16 @@ How do I use it?
 ::
 
    import butterdb
+   import json
+
+   # For getting OAuth Credential JSON file see http://gspread.readthedocs.org/en/latest/oauth2.html
+   # Ensure that the client_email has been granted privileges to any workbooks you wish to access.
+
+   json_key = json.load(open('SomeGoogleProject-2a31d827b2a9.json'))
+   client_email = json_key['client_email']
+   private_key = str(json_key['private_key']).encode('utf-8')
    
-   database = butterdb.Database("MyDatabaseSheet", "foo@google.com", "password")
+   database = butterdb.Database(name="MyDatabaseSheet", client_email=client_email, private_key=private_key)
    
    @butterdb.register(database)
    class User(butterdb.Model):

--- a/butterdb/butterdb.py
+++ b/butterdb/butterdb.py
@@ -1,7 +1,6 @@
 """butterdb is a Python ORM for Google Drive Spreadsheets."""
-
-
 import gspread
+from oauth2client.client import SignedJwtAssertionCredentials
 
 
 def register(database):
@@ -16,14 +15,22 @@ def register(database):
 
 class Database(object):
     """
-    Interacts with Google Spreadsheet.
+    Interacts with Google Spreadsheet using OAuth2.
     Registers models and updates and reads data.
     """
 
-    def __init__(self, name, username, password):
+    def __init__(self, name, client_email=None, private_key=None, username=None, password=None):
+        if username or password:
+            msg = 'Simple authentication has been deprecated.  Please use OAuth2.' + \
+                  '\nSee http://gspread.readthedocs.org/en/latest/oauth2.html'
+            raise Exception(msg)
+
         self.models = {}
         self.name = name
-        self.client = gspread.login(username, password)
+
+        scope = ['https://spreadsheets.google.com/feeds']
+        credentials = SignedJwtAssertionCredentials(client_email, private_key, scope)
+        self.client = gspread.authorize(credentials)
         self.db = self.client.open(name)
 
     def get_worksheet_names(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 gspread>=0.1.0
+oauth2client>=1.4.11

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
     package_dir={'butterdb': 'butterdb'},
     include_package_data=True,
     install_requires=[
-        'gspread'
+        'gspread',
+        'oauth2client'
     ],
     license="MIT",
     zip_safe=False,


### PR DESCRIPTION
In May 2015, google drive requires OAuth2 to connect to workbooks

Deprecate use of gspread.login() and use gspread.authorize() to implement OAuth2
